### PR TITLE
Integer values are being inappropriately

### DIFF
--- a/lib/incsv/types/string.rb
+++ b/lib/incsv/types/string.rb
@@ -6,6 +6,10 @@ module InCSV
     # therefore simple: it matches anything. For this reason it must be
     # matched last; this is achieved via require order.
     class String < ColumnType
+      def self.for_database
+        "TEXT"
+      end
+
       def match?
         true
       end

--- a/spec/lib/incsv/column_spec.rb
+++ b/spec/lib/incsv/column_spec.rb
@@ -37,6 +37,10 @@ module InCSV
           expect(Types::String.new("foo").match?).to be_truthy
           expect(Types::String.new(nil).match?).to be_truthy
         end
+
+        it "stores data as a TEXT column in the database" do
+          expect(Types::String.for_database).to eq("TEXT")
+        end
       end
     end
 
@@ -83,6 +87,11 @@ module InCSV
 
       it "interprets unknown formats as strings" do
         column = Column.new("foo", ["foo", "bar"])
+        expect(column.type.name).to eq(:string)
+      end
+
+      it "interprets numbers as strings" do
+        column = Column.new("foo", ["775763369311", "775763362199", "640506331617", "640506331606"])
         expect(column.type.name).to eq(:string)
       end
     end


### PR DESCRIPTION
Sample CSV attached. These should be strings containing integers, and shouldn't be treated as integers at all. Not sure the best way to handle this because either use case is valid. Maybe some configure option? `--FIELDNAME "FIELDTYPE"` to override the built-in behaviour?

```
> @db["select * from integer where _incsv_id = 5"].to_a
=> [{:_incsv_id=>5, :date=>"2016-02-29T23:51:45+00:00", :tracking=>9.27489999220832e+21}]
> @db["select * from integer where _incsv_id = 5"].to_a.first[:tracking]
=> 9.27489999220832e+21
> @db["select * from integer where _incsv_id = 5"].to_a.first[:tracking].to_s
=> "9.27489999220832e+21"

```

[integer.zip](https://github.com/robmiller/incsv/files/153493/integer.zip)
